### PR TITLE
Finish URL loading when observing requests to make sure all URL reque…

### DIFF
--- a/EssentialFeed/EssentialFeedTests/Feed Api/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Api/URLSessionHTTPClientTests.swift
@@ -182,7 +182,6 @@ final class URLSessionHTTPClientTests: XCTestCase {
         }
         
         override class func canInit(with request: URLRequest) -> Bool {
-            requestObserver?(request)
             return true
         }
         
@@ -191,6 +190,11 @@ final class URLSessionHTTPClientTests: XCTestCase {
         }
         
         override func startLoading() {
+            if let requestObserver = URLProtocolStub.requestObserver {
+                client?.urlProtocolDidFinishLoading(self)
+                return requestObserver(request)
+            }
+            
             if let data = URLProtocolStub.stub?.data {
                 client?.urlProtocol(self, didLoad: data)
             }


### PR DESCRIPTION
…sts are finished before the test method returns. This way, we prevent data races with threads living longer than the test method that initiated them.