### PR TITLE
Rename RemoteFeedLoaderTests to reflect the use case it refers to (Load Feed From Remote)

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7B307B3A2AD4C0B800D27BA7 /* RemoteFeedLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B307B392AD4C0B800D27BA7 /* RemoteFeedLoaderTests.swift */; };
+		7B307B3A2AD4C0B800D27BA7 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B307B392AD4C0B800D27BA7 /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		7B495DD62AD3BC12006EEE28 /* EssentialFeed.docc in Sources */ = {isa = PBXBuildFile; fileRef = 7B495DD52AD3BC12006EEE28 /* EssentialFeed.docc */; };
 		7B495DDC2AD3BC13006EEE28 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B495DD12AD3BC12006EEE28 /* EssentialFeed.framework */; };
 		7B495DE22AD3BC13006EEE28 /* EssentialFeed.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B495DD42AD3BC12006EEE28 /* EssentialFeed.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -42,7 +42,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		7B307B392AD4C0B800D27BA7 /* RemoteFeedLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoaderTests.swift; sourceTree = "<group>"; };
+		7B307B392AD4C0B800D27BA7 /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		7B495DD12AD3BC12006EEE28 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B495DD42AD3BC12006EEE28 /* EssentialFeed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EssentialFeed.h; sourceTree = "<group>"; };
 		7B495DD52AD3BC12006EEE28 /* EssentialFeed.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = EssentialFeed.docc; sourceTree = "<group>"; };
@@ -155,7 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				7BE7B44E2AE243CB00019458 /* Helper */,
-				7B307B392AD4C0B800D27BA7 /* RemoteFeedLoaderTests.swift */,
+				7B307B392AD4C0B800D27BA7 /* LoadFeedFromRemoteUseCaseTests.swift */,
 				7BE7B44C2ADDF01D00019458 /* URLSessionHTTPClientTests.swift */,
 			);
 			path = "Feed Api";
@@ -329,7 +329,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B307B3A2AD4C0B800D27BA7 /* RemoteFeedLoaderTests.swift in Sources */,
+				7B307B3A2AD4C0B800D27BA7 /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,
 				7BE7B44D2ADDF01D00019458 /* URLSessionHTTPClientTests.swift in Sources */,
 				7BE7B4502AE243FA00019458 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);

--- a/EssentialFeed/EssentialFeedTests/Feed Api/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Api/LoadFeedFromRemoteUseCaseTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import EssentialFeed
 
-class RemoteFeedLoaderTests: XCTestCase {
+class LoadFeedFromRemoteUseCaseTests: XCTestCase {
     
     func test_init_doesNotRequestDataFromURL() {
         let (_, client) = makeSUT()


### PR DESCRIPTION
…ad Feed From Remote)Rename RemoteFeedLoaderTests to reflect the use case it refers to (Load Feed From Remote)